### PR TITLE
Correction in English pokémon name for Clefable

### DIFF
--- a/values/pokemon.xml
+++ b/values/pokemon.xml
@@ -35,7 +35,7 @@
     <string name="p33">Nidorino</string>
     <string name="p34">Nidoking</string>
     <string name="p35">Clefairy</string>
-    <string name="p36">Melodelfe</string>
+    <string name="p36">Clefable</string>
     <string name="p37">Vulpix</string>
     <string name="p38">Ninetales</string>
     <string name="p39">Jigglypuff</string>


### PR DESCRIPTION
Used to be Melodelfe which is the French name for Clefable. Reported by @andybergon in Discord#Bugs
